### PR TITLE
Support commands from IRC

### DIFF
--- a/irc-command.js
+++ b/irc-command.js
@@ -1,0 +1,9 @@
+window.ircCommandHandlers = {};
+
+window.addEventListener('message', function(e) {
+    var commandSegments = e.data.split(' ');
+    
+    if (window.ircCommandHandlers.hasOwnProperty(commandSegments[0].toLowerCase())) {
+        window.ircCommandHandlers[commandSegments[0]](commandSegments.slice(1));
+    }
+});

--- a/irc/bigtext.js
+++ b/irc/bigtext.js
@@ -1,0 +1,22 @@
+function BigMessage() {
+    this.hideTimeout = null;
+    this.elem = document.getElementById('bigmessage');
+    this.textElem = document.getElementById('bigmessage-text');
+}
+
+BigMessage.prototype.show = function (text) {
+    this.textElem.textContent = text;
+    this.elem.className = 'visible';
+    clearTimeout(this.hideTimeout);
+    this.hideTimeout = window.setTimeout(this.hide.bind(this), 10000);
+}
+
+BigMessage.prototype.hide = function() {
+    this.elem.className = '';
+}
+
+var bigMsg = new BigMessage();
+
+window.ircCommandHandlers['bigtext'] = function(args) {
+    bigMsg.show(args.join(' '));
+}

--- a/kiosk.html
+++ b/kiosk.html
@@ -68,6 +68,69 @@ color: #CFCFCF;
   #here:before { content: "· "; }
   #status { display: none }
 /*  #here { overflow: hidden; text-overflow: ellipsis; } */
+
+  @keyframes bm-blink {
+    0% {
+      color: blue;
+      background-color: yellow;
+    }
+    50% {
+      color: yellow;
+      background-color: blue;
+    }
+    100% {
+      color: blue;
+      background-color: yellow;
+    }
+  }
+  @-webkit-keyframes bm-blink {
+    0% {
+      color: blue;
+      background-color: yellow;
+    }
+    50% {
+      color: yellow;
+      background-color: blue;
+    }
+    100% {
+      color: blue;
+      background-color: yellow;
+    }
+  }
+
+  #bigmessage {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+  }
+
+  #bigmessage-text {
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    background-color: white;
+    color: black;
+    font-size: 80px;
+    padding: 20px 0;
+    -webkit-animation-duration: 1000ms;
+    -webkit-animation-name: bm-blink;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-direction: alternate;
+    -webkit-animation-timing-function: steps(1);
+    animation-duration: 1000ms;
+    animation-name: bm-blink;
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
+    animation-timing-function: steps(1);
+  }
+
+  #bigmessage.visible {
+    display: block;
+  }
 </style>
 </head>
 <body>
@@ -116,16 +179,15 @@ color: #CFCFCF;
 })();
 </script>
 
-<script>window.setInterval(
-function(){
-  var h=document.querySelector("h1");
-  h.innerHTML=h.innerHTML.replace(
-    / .*/, Math.random()<.5?' eye are see':' aye arr sea');
-				 },30000);
-</script>
-
 <script src="status.js"></script>
 <script>getstatus()</script>
+
+<script src="irc-command.js"></script>
+
+<div id="bigmessage">
+  <div id="bigmessage-text"></div>
+</div>
+<script src="irc/bigtext.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Add support for a mini plugin system that can handle commands issued via IRC. Commands can be triggered by posting in IRC in the following format: "irc-client-nick: pluginname arg1 arg2 argn"

Plugins reside in the "irc" directory. I have created a basic "big text" plugin that displays text in blue and yellow flashing text for 10 seconds (useful for announcing food etc.)
