### PR TITLE
Enable switching of cameras through IRC commands

### DIFF
--- a/CamController.js
+++ b/CamController.js
@@ -19,11 +19,31 @@ function CamController(el, rotateDelay) {
 
 CamController.prototype.nextCam = function() {
     this.currentCam = (this.currentCam+1) % this.rotateCams.length;
-    console.log('Rotating to cam ' + this.cams[this.rotateCams[this.currentCam]].title);
+    this.switchTo(this.rotateCams[this.currentCam]);
+}
+
+CamController.prototype.startRotation = function() {
+    if (!this.rotateInterval) {
+        console.log('Starting camera rotation');
+        this.rotateInterval = window.setInterval(this.nextCam.bind(this), this.rotateDelay);
+    }
+}
+
+CamController.prototype.stopRotation = function() {
+    console.log('Stopping camera rotation');
+    window.clearInterval(this.rotateInterval);
+    this.rotateInterval = null;
+}
+
+CamController.prototype.switchTo = function(cameraName) {
+    if (!this.cams.hasOwnProperty(cameraName)) {
+        console.log('Nonexistent camera ' + cameraName);
+    }
+    console.log('Switching to cam ' + this.cams[cameraName].title);
 
     var img = new Image();
     img.addEventListener('load', function() {
-        console.log('Loaded cam ' + this.cams[this.rotateCams[this.currentCam]].title);
+        console.log('Loaded cam ' + this.cams[cameraName].title);
         this.element.replaceChild(img, this.element.querySelector('img'));
     }.bind(this));
 
@@ -32,16 +52,5 @@ CamController.prototype.nextCam = function() {
         setTimeout(this.nextCam.bind(this), 1000);
     }.bind(this));
 
-    img.src = this.cams[this.rotateCams[this.currentCam]].url;
-}
-
-CamController.prototype.startRotation = function() {
-    if (this.rotateInterval !== null) {
-        this.rotateInterval = window.setInterval(this.nextCam.bind(this), this.rotateDelay);
-    }
-}
-
-CamController.prototype.stopRotation = function() {
-    window.clearInterval(this.rotateInterval);
-    this.rotateInterval = null;
+    img.src = this.cams[cameraName].url;
 }

--- a/cam.js
+++ b/cam.js
@@ -1,32 +1,47 @@
-var cam = function(el) {
-    var cams = [
-        'http://gateway.hackspace:8082', // Cam 2, covering car park
-        'http://gateway.hackspace:8083', // Cam 3, by soldering station
-        'http://gateway.hackspace:8084', // Cam 4, internal door
-        'http://wifihifi.hackspace:8081', // Cam 5, on gateway cabinet
-        'http://wifihifi.hackspace:8082', // Cam 6, outside door
-        'http://3dprinter.hackspace:8081', // Cam 7, 3D printer camera
-    ];
-    
-    var n = 0;
-    var backoff = 0;
+function CamController(el, rotateDelay) {
+    this.element = el;
+    this.rotateDelay = rotateDelay;
 
-    function nextCam() {
-        n = (n+1) % cams.length;
-        var img = new Image();
-        img.onload = function() {
-	    console.log("success");
-            el.replaceChild(img, el.querySelector('img'));
-        };
-        img.onerror = function() {
-            console.error("Camera failed to load: " + img.src);
-	    setTimeout(nextCam, backoff);
-	    backoff += 1000;
-        };
+    this.cams = {
+        'carpark': {title: 'Car park', url: 'http://gateway.hackspace:8082'},
+        'main1': {title: 'Main room 1', url: 'http://gateway.hackspace:8083'}, // by soldering station
+        'door': {title: 'Internal door', url: 'http://gateway.hackspace:8084'},
+        'main2': {title: 'Main room 2', url: 'http://wifihifi.hackspace:8081'}, // on gateway cabinet
+        'outside': {title: 'Outside door', url: 'http://wifihifi.hackspace:8082'},
+        '3dprinter': {title: '3D printer', url: 'http://3dprinter.hackspace:8081'}
+    };
 
-        img.src = cams[n];
-    }
+    this.rotateCams = ['carpark', 'outside', '3dprinter'];
+    this.currentCam = 0;
 
-    setInterval(nextCam, 15000);
-    nextCam();
+    this.nextCam();
 };
+
+CamController.prototype.nextCam = function() {
+    this.currentCam = (this.currentCam+1) % this.rotateCams.length;
+    console.log('Rotating to cam ' + this.cams[this.rotateCams[this.currentCam]].title);
+
+    var img = new Image();
+    img.addEventListener('load', function() {
+        console.log('Loaded cam ' + this.cams[this.rotateCams[this.currentCam]].title);
+        this.element.replaceChild(img, this.element.querySelector('img'));
+    }.bind(this));
+
+    img.addEventListener('error', function() {
+        console.log('Camera failed to load: ' + img.src);
+        setTimeout(this.nextCam.bind(this), 1000);
+    }.bind(this));
+
+    img.src = this.cams[this.rotateCams[this.currentCam]].url;
+}
+
+CamController.prototype.startRotation = function() {
+    if (this.rotateInterval !== null) {
+        this.rotateInterval = window.setInterval(this.nextCam.bind(this), this.rotateDelay);
+    }
+}
+
+CamController.prototype.stopRotation = function() {
+    window.clearInterval(this.rotateInterval);
+    this.rotateInterval = null;
+}

--- a/irc-command.js
+++ b/irc-command.js
@@ -1,5 +1,9 @@
 window.ircCommandHandlers = {};
 
+function registerIrcCommandHandler(cmdName, handler) {
+    window.ircCommandHandlers[cmdName] = handler;
+}
+
 window.addEventListener('message', function(e) {
     var commandSegments = e.data.split(' ');
     

--- a/irc/bigtext.js
+++ b/irc/bigtext.js
@@ -17,6 +17,6 @@ BigMessage.prototype.hide = function() {
 
 var bigMsg = new BigMessage();
 
-window.ircCommandHandlers['bigtext'] = function(args) {
+registerIrcCommandHandler('bigtext', function(args) {
     bigMsg.show(args.join(' '));
-}
+});

--- a/irc/cam.js
+++ b/irc/cam.js
@@ -1,0 +1,56 @@
+function CamIrcConnector(controller) {
+    this.controller = controller;
+
+    registerIrcCommandHandler('cam', function (cmdArgs) {
+        console.log('CamIrcConnector handling ', cmdArgs);
+        var cmd = cmdArgs[0];
+        var args = cmdArgs.slice(1);
+
+        switch (cmd) {
+            case 'fix':
+                // View a particular camera until told otherwise
+                if (args.length === 1) {
+                    this.fixCam(args[0]);
+                }
+                break;
+
+            case 'view':
+                // Switch to a particular camera temporarily, then resume rotation
+                if (args.length === 1) {
+                    this.viewCam(args[0]);
+                }
+                break;
+
+            case 'resume':
+                // Resume rotating through cameras
+                this.rotateCams();
+                break;
+        }
+    }.bind(this));
+}
+
+CamIrcConnector.prototype.fixCam = function (camName) {
+    this.controller.stopRotation();
+    this.controller.switchTo(camName);
+}
+
+CamIrcConnector.prototype.viewCam = function (camName) {
+    if (this.restartRotationTimeout) {
+        clearTimeout(this.restartRotationTimeout);
+    }
+    this.controller.stopRotation();
+    this.controller.switchTo(camName);
+    this.restartRotationTimeout = setTimeout(function () {
+        this.restartRotationTimeout = null;
+        this.controller.startRotation();
+    }.bind(this), 30000);
+}
+
+CamIrcConnector.prototype.rotateCams = function () {
+    this.controller.startRotation();
+    if (this.restartRotationTimeout) {
+        clearTimeout(this.restartRotationTimeout);
+    }
+}
+
+new CamIrcConnector(camController);

--- a/kiosk.html
+++ b/kiosk.html
@@ -51,10 +51,8 @@
 
     <script src="cam.js"></script>
     <script>
-      (function() {
-      var el=document.getElementById("cam");
-      cam(el);
-      })();
+      var cam = new CamController(document.getElementById("cam"), 15000);
+      cam.startRotation();
     </script>
 
     <script src="status.js"></script>

--- a/kiosk.html
+++ b/kiosk.html
@@ -49,10 +49,10 @@
       })();
     </script>
 
-    <script src="cam.js"></script>
+    <script src="CamController.js"></script>
     <script>
-      var cam = new CamController(document.getElementById("cam"), 15000);
-      cam.startRotation();
+      var camController = new CamController(document.getElementById("cam"), 15000);
+      camController.startRotation();
     </script>
 
     <script src="status.js"></script>
@@ -64,6 +64,7 @@
       <div id="bigmessage-text"></div>
     </div>
     <script src="irc/bigtext.js"></script>
+    <script src="irc/cam.js"></script>
 
   </body>
 </html>

--- a/kiosk.html
+++ b/kiosk.html
@@ -7,7 +7,7 @@
   <body>
     <div id="header">
       <img src="logo.svg" style="width:1.2em; height:1.2em; position: relative; top: 0.15em; left: 0.1em">
-      <span id=space>Leeds Hackspace</span><span id=status> · <span id=temp></span> · <span id=state></span> <span id=here></span></span> <span id=time></span>
+      <span id="space">Leeds Hackspace</span><span id="status"> · <span id="temp"></span> · <span id="state"></span> <span id="here"></span></span> <span id="time"></span>
     </div>
     <table>
       <tr>


### PR DESCRIPTION
Add the new IRC command "cam" with the following functions:
- fix <camname> - fix the view to a particular camera indefinitely
- resume - resume scrolling through cameras
- view <camname> - view a particular camera for 30 seconds, then resume scrolling.

Cameras available: carpark, main1, door, main2, outside, 3dprinter
