### PR TITLE
Support commands via PMs

### DIFF
--- a/irc-command.js
+++ b/irc-command.js
@@ -5,9 +5,47 @@ function registerIrcCommandHandler(cmdName, handler) {
 }
 
 window.addEventListener('message', function(e) {
-    var commandSegments = e.data.split(' ');
+    /*
+    e.data looks like this:
+
+    {
+        sender: 'lhs-status',
+        type: 'highlight',
+        text: 'some message that was sent by mentioning us'
+    }
+
+    or
+
+    {
+        sender: 'lhs-status',
+        type: 'message',
+        text: 'some message that was sent either as a PM or as a message to the main channel (no way to tell which)'
+    }
+    */
+
+    if (!(typeof e.data === 'object' && e.data.hasOwnProperty('sender') && e.data.sender === 'lhs-status')) {
+        // this message wasn't for us
+        return;
+    }
+
+    switch (e.data.type) {
+        case 'highlight':
+            handleMessageLine(e.data.text);
+            break;
+
+        case 'message':
+            if (e.data.text[0] === '^') {
+                handleMessageLine(a.slice(1));
+            }
+            break;
+    }
+
+});
+
+function handleMessageLine(line) {
+    var commandSegments = line.split(' ');
     
     if (window.ircCommandHandlers.hasOwnProperty(commandSegments[0].toLowerCase())) {
         window.ircCommandHandlers[commandSegments[0]](commandSegments.slice(1));
     }
-});
+}


### PR DESCRIPTION
You can now send commands to the status screen by sending them as a private message to Sauron.
Commands can now be triggered by starting the message with a caret (^), i.e. `^bigtext` is now a synonym of `Sauron-tv: bigtext`.

These methods all have the same behaviour:
- PM `^bigtext Hello`
- PM `Sauron-tv: bigtext Hello`
- Post in main channel `^bigtext Hello`
- Post in main channel `Sauron-tv: bigtext Hello`

The Shout plugin has already been updated to support this new behaviour.
